### PR TITLE
Follow activate order for after_build extensions

### DIFF
--- a/lib/middleman-smusher/extension.rb
+++ b/lib/middleman-smusher/extension.rb
@@ -3,35 +3,37 @@ module Middleman
     class << self
       def registered(app, options={})
         require "smusher"
-        
+
         # options[:service] ||= "SmushIt"
         options[:quiet] = true
-        
+
+        smush_dir, prefix = nil, nil
         app.after_configuration do
           smush_dir = if options.has_key?(:path)
             options.delete(:path)
           else
             File.join(build_dir, images_dir)
           end
-          
+
           prefix = build_dir + File::SEPARATOR
-        
-          after_build do |builder|
-            files = ::Smusher.class_eval do
-              images_in_folder(smush_dir)
-            end
-                  
-            files.each do |file|
-              ::Smusher.optimize_image(
-                [file],
-                options
-              )
-            
-              builder.say_status :smushed, file.sub(prefix, "")
-            end
+        end
+
+        app.after_build do |builder|
+          files = ::Smusher.class_eval do
+            images_in_folder(smush_dir)
+          end
+
+          files.each do |file|
+            ::Smusher.optimize_image(
+              [file],
+              options
+            )
+
+            builder.say_status :smushed, file.sub(prefix, "")
           end
         end
-      end  
+
+      end
       alias :included :registered
     end
   end


### PR DESCRIPTION
The registering of the after_build hook was delayed by the execution of the after_configuration hook. That way it is not possible to define the order of execution of after_build extensions that normally would follow the activate order in the config.rb of a Middleman project.

This is an issue when syncing to S3 in the build phase. You want to smush BEFORE syncing.
