### PR TITLE
Fix middleman v4 compatibility issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in middleman-smusher.gemspec
 gemspec

--- a/lib/middleman-smusher.rb
+++ b/lib/middleman-smusher.rb
@@ -1,7 +1,5 @@
 require "middleman-core"
 
-require "middleman-smusher/version"
-  
 ::Middleman::Extensions.register(:smusher) do
   require "middleman-smusher/extension"
   ::Middleman::Smusher

--- a/lib/middleman-smusher/extension.rb
+++ b/lib/middleman-smusher/extension.rb
@@ -1,8 +1,9 @@
+require 'middleman-core'
 
 module Middleman
   class Smusher < ::Middleman::Extension
     option :service, 'SmushIt', 'Smushing service (SmushIt, PunyPng)'
-    option :path, null, 'Path to images to smush, defaults to :images_dir if not set'
+    option :path, nil, 'Path to images to smush, defaults to :images_dir if not set'
     option :with_gifs, false, 'Also smush GIFs'
 
     def initialize(app, options_hash={}, &block)
@@ -12,13 +13,13 @@ module Middleman
 
     def after_build(builder)
       smush_dir = options.path || File.join(app.config[:build_dir], app.config[:images_dir])
-      prefix = build_dir + File::SEPARATOR
+      prefix = app.config[:build_dir] + File::SEPARATOR
 
       files = ::Smusher.send :images_in_folder, smush_dir, options.with_gifs
 
       files.each do |file|
-        ::Smusher.optimize_image(file, service: options.service, quiet: true, with_gifs: options.with_gifs)
-        builder.say_status :smushed, file.sub(prefix, "")
+        ::Smusher.optimize_image(file, service: options.service, quiet: true, convert_gifs: options.with_gifs)
+        builder.thor.say_status :smushed, file.sub(prefix, "")
       end
     end
   end

--- a/lib/middleman-smusher/extension.rb
+++ b/lib/middleman-smusher/extension.rb
@@ -1,4 +1,3 @@
-require 'smusher'
 
 module Middleman
   class Smusher < ::Middleman::Extension
@@ -8,6 +7,7 @@ module Middleman
 
     def initialize(app, options_hash={}, &block)
       super
+      require 'smusher'
     end
 
     def after_build(builder)

--- a/lib/middleman-smusher/version.rb
+++ b/lib/middleman-smusher/version.rb
@@ -1,5 +1,0 @@
-module Middleman
-  module Smusher
-    VERSION = "4.0.0"
-  end
-end

--- a/middleman-smusher.gemspec
+++ b/middleman-smusher.gemspec
@@ -1,10 +1,9 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "middleman-smusher/version"
 
 Gem::Specification.new do |s|
   s.name        = "middleman-smusher"
-  s.version     = Middleman::Smusher::VERSION
+  s.version     = '4.0.0'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Thomas Reynolds"]
   s.email       = ["me@tdreyno.com"]

--- a/middleman-smusher.gemspec
+++ b/middleman-smusher.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   # s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency("middleman-core", [">= 3.2.0"])
+  s.add_runtime_dependency("middleman-core", [">= 4.2.1"])
   s.add_runtime_dependency("smusher", ["~> 0.4.9"])
 end


### PR DESCRIPTION
I was facing a number of incompatibilities, when trying to use middleman-smusher with a current middleman v4.2.1. This pull request tries to address all of them. Please take a look at the individual commits for a detailed description of the changes.